### PR TITLE
Change layout to work better on lowres screens

### DIFF
--- a/content/HBB_script.js
+++ b/content/HBB_script.js
@@ -402,28 +402,21 @@
   function size_content() {
     var container = $("html");
     var top_container = $(".top_container");
-    var bottom_container = $(".bottom_container");
-    var sloan_gutter = $(".sloan_gutter");
     var wwtcanvas = $("#wwtcanvas");
 
     // Constants here must be synced with settings in style.css
-    const new_wwt_width = (top_container.width() - sloan_gutter.width());
-    const new_wwt_height = sloan_gutter.height() - 2;
+    //const new_wwt_width = (top_container.width() - sloan_gutter.width());
+    const new_wwt_height = top_container.height() - 2;
     // set wwt_canvas height to fill top_container, subtract 3 to account for border width
 
     const colophon_height = $("#colophon").height();
-    const bottom_height = container.height() - top_container.outerHeight() - 50;
+    const bottom_height = container.height() - top_container.outerHeight() - 80;
     const description_height = bottom_height - colophon_height;
 
     // resize wwtcanvas with new values
     $(wwtcanvas).css({
-      "width": new_wwt_width + "px",
+      //"width": $(".right_container").width() + "px",
       "height": new_wwt_height + "px"
-    });
-
-    // resize bottom container to new value
-    $(bottom_container).css({
-      "height": bottom_height + "px"
     });
 
     // resize description box to new value

--- a/content/index.html
+++ b/content/index.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-    <div class="top_container">
+    <div class="left_col">
         <div class="sloan_gutter">
             <div id="sloan_image_holder">
                 <img src="cosmos_map.png" alt="cosmos map">
@@ -43,7 +43,7 @@
             </div>
             <div id="footnote">
                 <p>
-                    The cosmos map shows data from the <a href="https://www.sdss.org/" target="_blank"> Sloan Digitial Sky Survey</a> and the <a href="http://www.2dfgrs.net/" target="_blank">2dF Galaxy Redshift Survey</a>, <a href="https://github.com/Samreay/SurveyVisualiser" target="_blank">visualized</a> by Samuel Hinton.
+                    This cosmos map shows data from the <a href="https://www.sdss.org/" target="_blank"> Sloan Digitial Sky Survey</a> and the <a href="http://www.2dfgrs.net/" target="_blank">2dF Galaxy Redshift Survey</a>, <a href="https://github.com/Samreay/SurveyVisualiser" target="_blank">visualized</a> by Samuel Hinton.
                 </p>
             </div>
             <div id="dist_instrux">
@@ -66,117 +66,100 @@
                 </ol>
             </div>
         </div>
-        
-        <div id="wwtcanvas">
-            <h1 id="page_title">Hubble and the Big Bang</h1>
-            <div id="angle_distance_container">
-                <div id="angle_measures">
-                    <!-- <span id="galaxy_length_text">Assumed size for this galaxy type:<br></span>
-                    <span id="galaxy_length_text"><span class="value" id="galaxy_length_val"></span><br></span> -->
-                    <span id="zoom_ddmmss_text">
-                        height of display<br> 
-                    <span class="value" id="zoom_ddmmss_val"></span><br></span>
-                </div>
-                <div id="distance_measure">
-                    estimated distance<br>
-                    <span class="value" id="distance_val">&nbsp;</span>
-                </div>
-                <div id="distance_button">
-                    <span id="distance_text"><a href="#">ESTIMATE DISTANCE</a></span>
-                </div>
-            </div>
-            <a id="reset_target" class="fa-stack fa-sm" href="#" title="reset">
-                <i class="far fa-circle fa-stack-2x"></i>
-                <i class="fas fa-redo-alt fa-stack-1x"></i>
-            </a>
-            <div id="zoom_pan_container">
-                <div id="zoom_pan_instrux">
-                    <span class="smallcaps">zoom:</span> scroll in and out (or use the <strong>I-O</strong> keys for finer zoom)<br>
-                    <span class="smallcaps">rotate:</span> hold <strong>control</strong> and click + drag to the left or right<br>
-                    <span class="smallcaps">pan:</span> click + drag (or use the <strong>W-A-S-D</strong> keys)
-                </div>
-            </div>
-
-            <div id="one_spectrum" class="spectrum_popup shadow-lg">
-                <img src="images/NGC6052_Spectrum.jpeg" alt="first spectrum">
-                <i class="fas fa-times-circle close_spectrum"></i>
-            </div>
-            <div id="two_spectrum" class="spectrum_popup shadow-lg">
-                <img src="images/Haro11_Spectrum.jpeg" alt="second spectrum">
-                <i class="fas fa-times-circle close_spectrum"></i>
-            </div>
-            <div id="three_spectrum" class="spectrum_popup shadow-lg">
-                <img src="images/SDSSJ143450_Spectrum.jpeg" alt="third spectrum">
-                <i class="fas fa-times-circle close_spectrum"></i>
-            </div>
-            <div id="four_spectrum" class="spectrum_popup shadow-lg">
-                <img src="images/UGC2369_Spectrum.jpeg" alt="fourth spectrum">
-                <i class="fas fa-times-circle close_spectrum"></i>
-            </div>
-            <div id="five_spectrum" class="spectrum_popup shadow-lg">
-                <img src="images/J095000_Spectrum.jpeg" alt="fifth spectrum">
-                <i class="fas fa-times-circle close_spectrum"></i>
-            </div>
-            <div id="six_spectrum" class="spectrum_popup shadow-lg">
-                <img src="images/GOODS-North_Spectrum.jpeg" alt="sixth spectrum">
-                <i class="fas fa-times-circle close_spectrum"></i>
-            </div>
-            <div id="seven_spectrum" class="spectrum_popup shadow-lg">
-                <img src="images/HerculesA_Spectrum.jpeg" alt="seventh spectrum">
-                <i class="fas fa-times-circle close_spectrum"></i>
-            </div>
-            <div id="eight_spectrum" class="spectrum_popup shadow-lg">
-                <img src="images/Abell370_Spectrum.jpeg" alt="eighth spectrum">
-                <i class="fas fa-times-circle close_spectrum"></i>
-            </div>
-        </div>
     </div>
         
-    <div class="container-fluid bottom_container">
-        <div id="description_box">
-            <div id="description_container">
-                <div class="obj_desc">
-                    <div class="points_expl">
-                        <p>
-                            Click on one of the blue points on the map of our cosmos to fly to the selected galaxy.
+    <div class="right_col">
+        <div class="top_container">
+             <div id="wwtcanvas">
+                <h1 id="page_title">Hubble and the Big Bang</h1>
+                <div id="angle_distance_container">
+                    <div id="angle_measures">
+                        <!-- <span id="galaxy_length_text">Assumed size for this galaxy type:<br></span>
+                        <span id="galaxy_length_text"><span class="value" id="galaxy_length_val"></span><br></span> -->
+                        <span id="zoom_ddmmss_text">
+                             height of display<br> 
+                        <span class="value" id="zoom_ddmmss_val"></span><br></span>
+                    </div>
+                    <div id="distance_measure">
+                        estimated distance<br>
+                        <span class="value" id="distance_val">&nbsp;</span>
+                    </div>
+                    <div id="distance_button">
+                        <span id="distance_text"><a href="#">ESTIMATE DISTANCE</a></span>
+                    </div>
+                </div>
+                <a id="reset_target" class="fa-stack fa-sm" href="#" title="reset">
+                    <i class="far fa-circle fa-stack-2x"></i>
+                    <i class="fas fa-redo-alt fa-stack-1x"></i>
+                </a>
+                <div id="zoom_pan_container">
+                     <div id="zoom_pan_instrux">
+                        <span class="smallcaps">zoom:</span> scroll in and out (or use the <strong>I-O</strong> keys for finer zoom)<br>
+                        <span class="smallcaps">rotate:</span> hold <strong>control</strong> and click + drag to the left or right<br>
+                        <span class="smallcaps">pan:</span> click + drag (or use the <strong>W-A-S-D</strong> keys)
+                    </div>
+                </div>
+
+                <div id="one_spectrum" class="spectrum_popup shadow-lg">
+                    <img src="images/NGC6052_Spectrum.jpeg" alt="first spectrum">
+                    <i class="fas fa-times-circle close_spectrum"></i>
+                </div>
+                <div id="two_spectrum" class="spectrum_popup shadow-lg">
+                    <img src="images/Haro11_Spectrum.jpeg" alt="second spectrum">
+                    <i class="fas fa-times-circle close_spectrum"></i>
+                </div>
+                <div id="three_spectrum" class="spectrum_popup shadow-lg">
+                    <img src="images/SDSSJ143450_Spectrum.jpeg" alt="third spectrum">
+                    <i class="fas fa-times-circle close_spectrum"></i>
+                </div>
+                <div id="four_spectrum" class="spectrum_popup shadow-lg">
+                    <img src="images/UGC2369_Spectrum.jpeg" alt="fourth spectrum">
+                    <i class="fas fa-times-circle close_spectrum"></i>
+                </div>
+                <div id="five_spectrum" class="spectrum_popup shadow-lg">
+                    <img src="images/J095000_Spectrum.jpeg" alt="fifth spectrum">
+                    <i class="fas fa-times-circle close_spectrum"></i>
+                </div>
+                <div id="six_spectrum" class="spectrum_popup shadow-lg">
+                    <img src="images/GOODS-North_Spectrum.jpeg" alt="sixth spectrum">
+                    <i class="fas fa-times-circle close_spectrum"></i>
+                </div>
+                <div id="seven_spectrum" class="spectrum_popup shadow-lg">
+                    <img src="images/HerculesA_Spectrum.jpeg" alt="seventh spectrum">
+                    <i class="fas fa-times-circle close_spectrum"></i>
+                </div>
+                <div id="eight_spectrum" class="spectrum_popup shadow-lg">
+                    <img src="images/Abell370_Spectrum.jpeg" alt="eighth spectrum">
+                    <i class="fas fa-times-circle close_spectrum"></i>
+                </div>
+            </div>
+        </div>
+        
+        <div class="container-fluid bottom_container">
+            <div id="description_box">
+                <div id="description_container">
+                    <div class="obj_desc">
+                        <div class="points_expl">
+                            <p>
+                                Click on one of the blue points on the map of our cosmos to fly to the selected galaxy.
+                            </p>
+                            <p>
+                                Double-click on the point to arrive there immediately.
+                            </p>
+                        </div>
+                        <h4 class="begin_ss_h4">Overview</h4>
+                        <p class="begin_ss_p">
+                            How do galaxies move within the cosmos? Is there a relationship between the positions of galaxies and how they move relative to us? What can these properties of galaxies tell us about the history of our Universe? 
                         </p>
-                        <p>
-                            Double-click on the point to arrive there immediately.
+                        <p class="begin_ss_p">
+                            In this activity, you will collect your own galaxy data to investigate these questions. You will use real spectra data to measure galaxy velocities, and you will use a "standard ruler" approach to estimate their distances. 
                         </p>
                     </div>
-                    <h4 class="begin_ss_h4">Overview</h4>
-                    <p class="begin_ss_p">
-                        How do galaxies move within the cosmos? Is there a relationship between the positions of galaxies and how they move relative to us? What can these properties of galaxies tell us about the history of our Universe? 
-                    </p>
-                    <p class="begin_ss_p">
-                        In this activity, you will collect your own galaxy data to investigate these questions. You will use real spectra data to measure galaxy velocities, and you will use a "standard ruler" approach to estimate their distances. 
-                    </p>
                 </div>
-            </div>
-            <i id="scroll_arrow" class="fas fa-arrow-down"></i>
-        </div>
-    </div>
-
-
-
-    <!-- beginning of target object description modal 
-    <div class="modal fade" id="objectModal">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h3 class="modal-title">The Periodic Table</h3>
-                </div>
-                <div class="modal-body text-info">
-                    <img src="PeriodicTablePlaceholder@0.75x.png" class="object_banner" alt="banner">
-                </div>
-                <div class="modal-footer">
-                    <span class="target_object_description">This is the Periodic Table description</span>
-                    <button type="button" class="btn btn-info" data-dismiss="modal">close</button>
-                </div>
+                <i id="scroll_arrow" class="fas fa-arrow-down"></i>
             </div>
         </div>
     </div>
--->
 
     <div id="colophon">
         <div id="colo_left">
@@ -197,7 +180,6 @@
             </p>
         </div>
     </div>
-
     <script src="HBB_script.js"></script>
 </body>
 

--- a/content/style.css
+++ b/content/style.css
@@ -12,14 +12,19 @@ html {
 body {
 	position: relative;
 	overflow: hidden;
-	margin: 0px;
-	padding: 0px;
+    display: flex;
+    width: 90%;
+    margin: auto;
+    padding: 30px 0 0 0;
 	color: #FFF;
 	height: 100%;
 	background-color: #111;
 	font-size: calc(11px + 0.6vw);
 }
 
+.left_col {
+    flex: 0 0 300px;
+}
 
 
 /* Generic element settings */
@@ -50,18 +55,13 @@ a, a:hover {
 
 .top_container {
     display: flex;
-    width: 90%;
-    min-height: 50%;
-    margin: auto;
-    padding-top: 30px;
+    min-height: 60%;
+    max-height: 75%;
 }
 
 .bottom_container {
 	padding: 0;
-	width: 90%;
-	margin: 0px 5%;
 }
-
 
 
 /* Sloan image and plot points. */
@@ -76,7 +76,7 @@ a, a:hover {
 }
 
 .sloan_gutter img {
-    width: 250px;
+    width: 300px;
 	border: solid 1px #333;
 }
 
@@ -84,10 +84,10 @@ a, a:hover {
     position: absolute;
     top: 7px;
     left: 0;
-    padding: 2px 5px;
+    padding: 3px 5px;
     border-left: solid 2px #EFA928;
     color: #EFA928;
-    font-size: 10px;
+    font-size: 12px;
     font-weight: bold;
 }
 
@@ -114,13 +114,13 @@ a, a:hover {
 
 .sloan_gutter #dist_instrux {
     visibility: hidden;
-    width: 250px;
-    margin-top: 5px;
+    width: 300px;
+    margin-top: 20px;
 	text-align: left;
-	font-size: 12px;
+	font-size: 13px;
     line-height: 1.4;
     color: #EEEEEECC;
-    padding: 5px;
+    padding: 10px;
     background-color: #00000066;
     border: solid 1px #333;
     overflow-y: auto;
@@ -128,22 +128,22 @@ a, a:hover {
 
 .sloan_gutter #dist_instrux h6 {
     color: #EFA928;
-    font-size: 13px;
+    font-size: 14px;
     font-weight: bold;
     font-variant: small-caps;
     text-align: center;
 }
 
 .sloan_gutter #dist_instrux li + * {
-    margin-top: 5px;
+    margin-top: 10px;
 }
 
 .sloan_gutter #dist_instrux .li_subtext {
-    margin: 4px 8px 2px 0;
-    padding: 3px 5px;
-    font-size: 0.8em;
+    margin: 6px 10px 3px 0;
+    padding: 5px 10px;
+    font-size: 0.95em;
     color: #EEEEEE;
-    border-radius: 2px;
+    border-radius: 3px;
     background-color: #EEEEEE22;
 }
 
@@ -154,11 +154,11 @@ a, a:hover {
 
 #footnote {
     position: absolute;
-    bottom: 0px;
+    top: 310px;
     padding-right: 20px;
     user-select: none;
     text-align: left;
-    color: #EEEEEECC; 
+    color: #e1e1e1; 
     font-size: 12px;
 }
 
@@ -167,7 +167,7 @@ a, a:hover {
 
 #wwtcanvas {
 	position: relative;
-	width: 90%;     /* note: overridden in HBB_script.js */
+	width: 99%;     /* note: overridden in HBB_script.js */
 	height: 100%;   /* note: overridden in HBB_script.js */
 	margin: auto;
 	border: solid 1px #333;


### PR DESCRIPTION
- Move cosmos map & distance instructions to left column, and WWT canvas & description box to right column. (Old layout with description box in its own row at the bottom made that content disappear on lowres screens).

- Resize wwtcanvas width from 90% to 99% to make it match better with description box.  (I wanted it to be 100%, but for some reason, the WWT canvas and description box would not resize properly when making the window narrower. Resizing works fine for 90% and 99%, so I chose 99%).

- Other small tweaks, many to undo a lot of the updates I made in previous commit to try to make the left column content less tall.