### PR TITLE
Update rotate controls to J/L instead of alt-A/D

### DIFF
--- a/content/HBB_script.js
+++ b/content/HBB_script.js
@@ -430,8 +430,6 @@
   // also triggering size_content function in the load_wtml function,
   // because thumbnails aren't loading immediately
 
-
-
   // Backend details: setting up keyboard controls.
   //
   // TODO: this code is from pywwt and was designed for use in Jupyter;
@@ -462,6 +460,9 @@
     const mouse_up = new_event("wwt-move", { movementX: 0, movementY: 53 }, true);
     const mouse_right = new_event("wwt-move", { movementX: -53, movementY: 0 }, true);
     const mouse_down = new_event("wwt-move", { movementX: 0, movementY: -53 }, true);
+    const rotate_left = new_event("wwt-rotate", { movementX: 53, movementY: 0 }, true);
+    const rotate_right = new_event("wwt-rotate", { movementX: -53, movementY: 0 }, true);
+
 
     const zoomCodes = {
       "KeyI": wheel_up,
@@ -475,10 +476,14 @@
       "KeyW": mouse_up,
       "KeyD": mouse_right,
       "KeyS": mouse_down,
+      "KeyJ": rotate_left,
+      "KeyL": rotate_right,
       65: mouse_left,
       87: mouse_up,
       68: mouse_right,
-      83: mouse_down
+      83: mouse_down,
+      74: rotate_left,
+      76: rotate_right,
     };
 
     window.addEventListener("keydown", function (event) {
@@ -496,6 +501,7 @@
 
         var action = zoomCodes.hasOwnProperty(event.code) ? zoomCodes[event.code] : zoomCodes[event.keyCode];
 
+        // Possible to cut this? I don't see action.shiftKey being used anywhere.
         if (event.shiftKey)
           action.shiftKey = 1;
         else
@@ -516,6 +522,8 @@
 
         var action = moveCodes.hasOwnProperty(event.code) ? moveCodes[event.code] : moveCodes[event.keyCode];
 
+
+        // Possible to cut this? I don't see action.shiftKey/altKey being used anywhere.
         if (event.shiftKey)
           action.shiftKey = 1
         else
@@ -542,10 +550,23 @@
 
         setTimeout(function () { proceed = true }, delay);
 
-        if (event.altKey)
-          wwt_ctl._tilt(event.movementX, event.movementY);
+        wwt_ctl.move(event.movementX, event.movementY);
+      }
+    })(true));
+
+    canvas.addEventListener("wwt-rotate", (function (proceed) {
+      return function (event) {
+        if (!proceed)
+          return false;
+
+        if (event.shiftKey)
+          delay = 500; // milliseconds
         else
-          wwt_ctl.move(event.movementX, event.movementY);
+          delay = 100;
+
+        setTimeout(function () { proceed = true }, delay);
+
+        wwt_ctl._tilt(event.movementX, event.movementY);
       }
     })(true));
 
@@ -570,6 +591,7 @@
 
       }
     })(true));
+
   }
 
   // when user scrolls to bottom of the description container, remove the down arrow icon. Add it back when scrolling back up.

--- a/content/index.html
+++ b/content/index.html
@@ -52,7 +52,7 @@
                     <li>
                         Rotate the galaxy in the white circle until the longest dimension of the galaxy is vertical
                         <div class="li_subtext">
-                            <span class="smallcaps">rotate:</span> hold <strong>control</strong> and click + drag to the left or right
+                            <span class="smallcaps">rotate:</span> hold <strong>control</strong> + click + drag to the left or right (or use the <strong>J-L</strong> keys)
                         </div>
                     </li>
                     <li>
@@ -95,7 +95,7 @@
                 <div id="zoom_pan_container">
                      <div id="zoom_pan_instrux">
                         <span class="smallcaps">zoom:</span> scroll in and out (or use the <strong>I-O</strong> keys for finer zoom)<br>
-                        <span class="smallcaps">rotate:</span> hold <strong>control</strong> and click + drag to the left or right<br>
+                        <span class="smallcaps">rotate:</span> hold <strong>control</strong> + click + drag to the left or right (or use the <strong>J-L</strong> keys)<br>
                         <span class="smallcaps">pan:</span> click + drag (or use the <strong>W-A-S-D</strong> keys)
                     </div>
                 </div>

--- a/content/style.css
+++ b/content/style.css
@@ -212,7 +212,7 @@ a, a:hover {
 #distance_text {
     border: 3px solid #41BEEC;
     border-radius: 15px;
-    padding: 4px 12px;
+    padding: 4px 8px;
     font-size: 0.7em;
     font-weight: bold;
 }
@@ -278,14 +278,14 @@ a, a:hover {
 }
 
 #zoom_pan_instrux {
-	width: 35em;
+	width: 38em;
     margin: 0 auto;
     padding: 2px;
 	text-align: center;
 	font-size: 0.6em;
 	color: #EEEEEECC;
     background-color: #00000066;
-    border-radius: 30px;
+    border-radius: 25px;
 }
 
 #zoom_pan_instrux strong {


### PR DESCRIPTION
- to avoid possible conflicts with existing OS/browser key mappings.
- Update instructions to include J-L keys
- Minor reformatting to prevent wrap in zoom_pan_instrux with added J-L instrux; shortened distance button width to avoid button colliding with instrux