### PR TITLE
Correct tab focusing to include description box and modal "close"

### DIFF
--- a/content/GHU_script.js
+++ b/content/GHU_script.js
@@ -661,5 +661,13 @@
     $(".spectrum_popup").hide();
     popup_open = false;
   })
+  
+  // Place focus on 'Close' button upon opening of modal
+  $(document).keydown(function(e) {
+    var key = e.which;
+    if (key == 27) {
+      $("#howtoModal").modal('hide');
+    }
+  })
 
 })();

--- a/content/index.html
+++ b/content/index.html
@@ -120,7 +120,7 @@
         
         <div class="container-fluid bottom_container">
             <div id="description_box">
-                <div id="description_container">
+                <div id="description_container" tabindex="0">
                     <div class="obj_desc">
                         <h4 class="begin_ss_h4">Overview of Interactive</h4>
                         <p class="begin_ss_p">
@@ -139,7 +139,7 @@
     				
     
     <!-- beginning of target object description modal -->
-    <div class="modal fade" id="howtoModal">
+    <div class="modal" id="howtoModal">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
@@ -170,7 +170,7 @@
                 </div>
                 <div class="modal-footer">
                     <span class="target_object_description"></span>
-                    <button type="button" class="btn btn-info" data-dismiss="modal">close</button>
+                    <button type="button" class="btn btn-info" data-dismiss="modal" autofocus>close</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Description box now included in tab hierarchy
- 'Close' gets autofocus on load, but I don't see the highlighting on Chrome. Still it's there.
- I also added esc key functionality to the modal to close